### PR TITLE
Trigger

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
@@ -5,7 +5,6 @@
 
         <Copyright>Copyright Aksio</Copyright>
         <Authors>all contributors</Authors>
-        
         <RepositoryUrl>https://github.com/aksio-system/Defaults</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
### Fixed

- NuGet package build fixed to not force the inclusion of symbols when some packages don't have them.

