### PR TITLE
Fixing message comparison to ignore case

### DIFF
--- a/Source/CodeAnalysis/ExceptionConstructorParametersShouldNotContainMessage/Analyzer.cs
+++ b/Source/CodeAnalysis/ExceptionConstructorParametersShouldNotContainMessage/Analyzer.cs
@@ -50,7 +50,7 @@
                     var wronglyNamedParameters = constructor.ParameterList.Parameters
                                                     .Where(_ =>
                                                         _.Type.ToString().EndsWith("string", StringComparison.InvariantCultureIgnoreCase) &&
-                                                        _.Identifier.Text.Contains("message"));
+                                                        _.Identifier.Text.IndexOf("message", StringComparison.InvariantCultureIgnoreCase) >= 0);
                     foreach (var parameter in wronglyNamedParameters)
                     {
                         var diagnostic = Diagnostic.Create(Rule, parameter.Identifier.GetLocation());


### PR DESCRIPTION
### Fixed

- Wrong target framework had been set. Supporting netstandard2.0.
- Fixing comparison of message for AS0006 to ignore case.
