### PR TITLE
Fix Xml doc generation + logo inclusion (not twice)

### DIFF
--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -23,7 +23,7 @@
     <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <DocumentationFile>$()../../Artifacts/$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsTestProject>false</IsTestProject>
 
     <IncludeSymbols>True</IncludeSymbols>
@@ -51,7 +51,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)logo.png" Pack="true" Visible="false" PackagePath="" />
     <Content Include="$(MSBuildThisFileDirectory)logo.png" PackagePath="" />
   </ItemGroup>
 


### PR DESCRIPTION
### Fixed

- Generate Xml documentation by default to default location (bin/<config>/<assemblyname>.xml).
- Fix an error where the Aksio logo asset was included twice.

