### PR TITLE
Turning off file header requirement

### DIFF
--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -14,6 +14,7 @@
         <Rule Id="SA1413" Action="None" />
         <Rule Id="SA1501" Action="None" />
         <Rule Id="SA1503" Action="None" />
+        <Rule Id="SA1633" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
         <Rule Id="IDE0003" Action="Error" />


### PR DESCRIPTION
### Fixed

- Disabling the StyleCop rule [SA1633](https://documentation.help/StyleCop/SA1633.html) as we are not requiring a file header.
