### PR TITLE
Adding missing rules discovered during work

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -16,7 +16,7 @@
 
     <LangVersion>10.0</LangVersion>
 
-    <NoWarn>NU5105;NU5118</NoWarn>
+    <NoWarn>NU5105;NU5118;CS1591;CS8632;CS8618</NoWarn>
     <Nullable>disable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="My Rules" ToolsVersion="15.0">
+<RuleSet Name="Aksio Rules for Specs" ToolsVersion="15.0">
     <!-- Rule Set Format : https://github.com/dotnet/roslyn/blob/master/docs/compilers/Rule%20Set%20Format.md -->
     <!-- Rule set reference : https://docs.microsoft.com/en-us/visualstudio/code-quality/rule-set-reference?view=vs-2019 -->
+    <!-- Rule set groups : https://docs.microsoft.com/en-us/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules?view=vs-2019 -->
 
     <Include Path="code_analysis_base.ruleset" Action="Default"/>
     
@@ -29,9 +30,10 @@
         <Rule Id="SA1600" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+        <Rule Id="IDE0044" Action="None" />
         <Rule Id="IDE0060" Action="None" />
         <Rule Id="IDE0051" Action="None" />
-        <Rule Id="IDE1006" Action="None" />
+        <Rule Id="IDE0052" Action="None" />
         <Rule Id="IDE1006" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
@@ -52,17 +54,17 @@
         <Rule Id="CA1812" Action="None" />
         <Rule Id="CA1819" Action="None" />
         <Rule Id="CA1823" Action="None" />
-        <Rule Id="CA1707" Action="None" />
-        <Rule Id="CS1591" Action="None" />
-        <Rule Id="CA1051" Action="None" />
+        <Rule Id="CA2211" Action="None" />
+        <Rule Id="CA2252" Action="None" />
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
+        <Rule Id="RCS1018" Action="None" />
         <Rule Id="RCS1079" Action="None" />
+        <Rule Id="RCS1090" Action="None" />
         <Rule Id="RCS1163" Action="None" />
         <Rule Id="RCS1169" Action="None" />
         <Rule Id="RCS1202" Action="None" />
         <Rule Id="RCS1213" Action="None" />
-        <Rule Id="RCS1090" Action="None" />
-        <Rule Id="RCS1213" Action="None" />
+        <Rule Id="RCS1225" Action="None" />
     </Rules>
 </RuleSet>

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="My Rules" ToolsVersion="15.0">
+<RuleSet Name="Aksio Rules" ToolsVersion="15.0">
     <!-- Rule Set Format : https://github.com/dotnet/roslyn/blob/master/docs/compilers/Rule%20Set%20Format.md -->
     <!-- Rule set reference : https://docs.microsoft.com/en-us/visualstudio/code-quality/rule-set-reference?view=vs-2019 -->
+    <!-- Rule set groups : https://docs.microsoft.com/en-us/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules?view=vs-2019 -->
+
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
         <Rule Id="SA1000" Action="None" />
         <Rule Id="SA1009" Action="None" />
@@ -28,7 +30,6 @@
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
     </Rules>  
     <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
-        
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
         <Rule Id="CA1000" Action="None" />
@@ -51,6 +52,7 @@
         <Rule Id="CA2211" Action="None" />
         <Rule Id="CA2225" Action="None" />
         <Rule Id="CA2227" Action="None" />
+        <Rule Id="CA2252" Action="None" />
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
         <Rule Id="RCS1018" Action="None" />


### PR DESCRIPTION
### Fixed

- Configuring missing rules to allow for both .NET 6 and Specs to be written with a natural language.

