### PR TITLE
Adding support for allowing NotImplementedException

### DIFF
--- a/Documentation/CodeAnalysis/Analyzers/AS0008.md
+++ b/Documentation/CodeAnalysis/Analyzers/AS0008.md
@@ -8,7 +8,7 @@ As with all other code; Exceptions has meaning. You should therefor not be throw
 generic exceptions provided by the .NET base class library as these does not have
 a specific meaning. This rule prevents you from throwing any exception that comes from
 any `System` namespace. Your exception should sit side-by-side the code that is
-throwing it.
+throwing it. There is one exception to the rule; it allows throwing [NotImplementedException](https://docs.microsoft.com/en-us/dotnet/api/system.notimplementedexception).
 
 Example of good specific exceptions:
 

--- a/Source/CodeAnalysis/ExceptionShouldBeSpecific/Analyzer.cs
+++ b/Source/CodeAnalysis/ExceptionShouldBeSpecific/Analyzer.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Represents the <see cref="DiagnosticDescriptor">rule</see> for the analyzer.
         /// </summary>
-        public static readonly DiagnosticDescriptor Rule = new (
+        public static readonly DiagnosticDescriptor Rule = new(
              id: "AS0008",
              title: "ExceptionShouldBeSpecific",
              messageFormat: "Throwing a generic system exception is not a allowed - you should create a specific exception",
@@ -46,8 +46,12 @@
                 if (exceptionOperation is IObjectCreationOperation exception &&
                     exception.Constructor.ContainingNamespace.Name.StartsWith("System", StringComparison.InvariantCulture))
                 {
-                    var diagnostic = Diagnostic.Create(Rule, throwOperation.Syntax.GetLocation());
-                    context.ReportDiagnostic(diagnostic);
+                    var fullName = $"{exception.Constructor.ContainingNamespace.Name}.{exception.Constructor.ContainingType.Name}";
+                    if (fullName != typeof(NotImplementedException).FullName)
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, throwOperation.Syntax.GetLocation());
+                        context.ReportDiagnostic(diagnostic);
+                    }
                 }
             }
         }

--- a/Specifications/CodeAnalysis/ExceptionShouldBeSpecific/UnitTests.cs
+++ b/Specifications/CodeAnalysis/ExceptionShouldBeSpecific/UnitTests.cs
@@ -92,6 +92,27 @@ namespace Aksio.CodeAnalysis.ExceptionShouldBeSpecific
             VerifyCSharpDiagnostic(content, expected);
         }
 
+        [Fact]
+        public void ThrowingNotImplementedException()
+        {
+            const string content = @"
+                using System;
+
+                namespace MyNamespace
+                {
+                    public class MyClass
+                    {
+                        public void MyMethod()
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                }       
+            ";
+
+            VerifyCSharpDiagnostic(content);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new Analyzer();


### PR DESCRIPTION
### Fixed

- [AS0008](./Documentation/CodeAnalysis/Analyzers/AS0008.md) rule was too strict; allowing for [NotImplementedException](https://docs.microsoft.com/en-us/dotnet/api/system.notimplementedexception).
