### PR TITLE
Adding $(NoWarn) in front of NoWarn setup

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -16,7 +16,7 @@
 
     <LangVersion>10.0</LangVersion>
 
-    <NoWarn>NU5105;NU5118;CS1591;CS8632;CS8618</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5118;CS1591;CS8632;CS8618</NoWarn>
     <Nullable>disable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -16,7 +16,7 @@
 
     <LangVersion>10.0</LangVersion>
 
-    <NoWarn>NU5105;NU5118</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5118</NoWarn>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>


### PR DESCRIPTION
### Fixed

- Adding `$(NoWarn)` in front of `<NoWarn/>` settings in props files - this will allow combining the common rules with specifics in either a **.csproj** file or a **Directory.Build.props** file. 
