### PR TITLE
Moving common rules out of editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,8 +63,6 @@ dotnet_naming_symbols.private_fields.required_modifiers                         
 dotnet_naming_style.private_fields.capitalization                               = camel_case
 dotnet_naming_style.private_fields.required_prefix                              = _
 
-
-
 # upper camelcase for public properties
 dotnet_naming_rule.public_members_must_be_capitalized.style = first_word_upper_case_style
 dotnet_naming_style.first_word_upper_case_style.capitalization = first_word_upper
@@ -72,40 +70,6 @@ dotnet_naming_rule.public_members_must_be_capitalized.symbols = public_symbols
 dotnet_naming_symbols.public_symbols.applicable_kinds = property,method,field,event,delegate
 dotnet_naming_symbols.public_symbols.applicable_accessibilities = public
 dotnet_naming_symbols.public_symbols.required_modifiers = readonly
-
-## Specific rule suppression
-# CA1822: Mark members as static
-dotnet_diagnostic.CA1822.severity = none
-# CA2016: Forward the CancellationToken parameter to methods that take one
-dotnet_diagnostic.CA2016.severity = none
-# CA1716: Identifiers should not match keywords
-dotnet_diagnostic.CA1716.severity = none
-# CA1725: Parameter names should match base declaration
-dotnet_diagnostic.CA1725.severity = none
-# CA1710: Identifiers should have correct suffix
-dotnet_diagnostic.CA1710.severity = none
-#CA1711: Identifiers should not have incorrect suffix
-dotnet_diagnostic.CA1711.severity = none
-# Add missing cases to switch expression (IDE0072 and IDE0010)
-# a bug in roslyn: https://github.com/dotnet/roslyn/issues/48876
-dotnet_diagnostic.IDE0072.severity = none
-dotnet_diagnostic.IDE0010.severity = none
-# IDE0130: Namespace does not match folder structure
-dotnet_diagnostic.IDE0130.severity = none
-# CA1834: Use StringBuilder.Append(char) for single character strings
-dotnet_diagnostic.CA1834.severity = none
-# CA1805: Do not initialize unnecessarily.
-dotnet_diagnostic.CA1805.severity = none
-# Use pattern matching (not operator) (IDE0083)
-dotnet_diagnostic.IDE0083.severity = none
-# CA1309: Use ordinal StringComparison
-dotnet_diagnostic.CA1309.severity = none
-# CA1000: Do not declare static members on generic types
-dotnet_diagnostic.CA1000.severity = none
-# RCS1018: Add accessibility modifiers
-dotnet_diagnostic.RCS1018.severity = none
-# RCS1194: Implement exception constructors
-dotnet_diagnostic.RCS1194.severity = none
 
 #### C# Coding Conventions ####
 
@@ -137,14 +101,10 @@ csharp_style_unused_value_expression_statement_preference = false:none
 
 # not ready for changing everything to pattern matching
 csharp_style_prefer_pattern_matching = false:none
-
 csharp_using_directive_placement = outside_namespace:error
-
-
 csharp_style_prefer_range_operator = false:none
 
 # CSharp formatting rules:
 # dont want these bombing the build logs, will still show up in the IDE
-dotnet_diagnostic.IDE0055.severity = none
 # prefere brace indentation when creating objects etc
 csharp_indent_braces = false

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -5,32 +5,47 @@
     <!-- Rule set groups : https://docs.microsoft.com/en-us/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules?view=vs-2019 -->
 
     <Include Path="code_analysis_base.ruleset" Action="Default"/>
-    
+   
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
         <Rule Id="SA0001" Action="None" />
+        <Rule Id="SA1009" Action="None" />
         <Rule Id="SA1012" Action="None" />
+        <Rule Id="SA1101" Action="None" />
         <Rule Id="SA1134" Action="None" />
         <Rule Id="SA1118" Action="None" />
         <Rule Id="SA1122" Action="None" />
         <Rule Id="SA1201" Action="None" />
         <Rule Id="SA1302" Action="None" />
+        <Rule Id="SA1300" Action="None" />
         <Rule Id="SA1303" Action="None" />
         <Rule Id="SA1304" Action="None" />
         <Rule Id="SA1306" Action="None" />
         <Rule Id="SA1307" Action="None" />
+        <Rule Id="SA1309" Action="None" />
         <Rule Id="SA1310" Action="None" />
         <Rule Id="SA1311" Action="None" />
+        <Rule Id="SA1400" Action="None" />
+        <Rule Id="SA1401" Action="None" />
+        <Rule Id="SA1413" Action="None" />
+        <Rule Id="SA1501" Action="None" />
         <Rule Id="SA1502" Action="None" />
+        <Rule Id="SA1503" Action="None" />
         <Rule Id="SA1516" Action="None" />
         <Rule Id="SA1600" Action="None" />
         <Rule Id="SA1633" Action="None" />
         <Rule Id="SA1649" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+        <Rule Id="IDE0010" Action="None" />
+        <Rule Id="IDE0040" Action="None" />
+        <Rule Id="IDE0040WithoutSuggestion" Action="None" />
         <Rule Id="IDE0044" Action="None" />
         <Rule Id="IDE0060" Action="None" />
         <Rule Id="IDE0051" Action="None" />
         <Rule Id="IDE0052" Action="None" />
+        <Rule Id="IDE0072" Action="None" />
+        <Rule Id="IDE0083" Action="None" />
+        <Rule Id="IDE0130" Action="None" />
         <Rule Id="IDE1006" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
@@ -38,28 +53,54 @@
     <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+        <Rule Id="CA1000" Action="None" />
+        <Rule Id="CA1031" Action="None" />
+        <Rule Id="CA1032" Action="None" />
+        <Rule Id="CA1040" Action="None" />
         <Rule Id="CA1051" Action="None" />
         <Rule Id="CA1052" Action="None" />
+        <Rule Id="CA1054" Action="None" />
+        <Rule Id="CA1056" Action="None" />
+        <Rule Id="CA1062" Action="None" />
+        <Rule Id="CA1063" Action="None" />
+        <Rule Id="CA1065" Action="None" />
+        <Rule Id="CA1303" Action="None" />
         <Rule Id="CA1304" Action="None" />
         <Rule Id="CA1305" Action="None" />
         <Rule Id="CA1307" Action="None" />
         <Rule Id="CA1308" Action="None" />
+        <Rule Id="CA1309" Action="None" />
         <Rule Id="CA1707" Action="None" />
+        <Rule Id="CA1710" Action="None" />
+        <Rule Id="CA1711" Action="None" />
         <Rule Id="CA1715" Action="None" />
+        <Rule Id="CA1716" Action="None" />
         <Rule Id="CA1720" Action="None" />
+        <Rule Id="CA1724" Action="None" />
+        <Rule Id="CA1725" Action="None" />
         <Rule Id="CA1801" Action="None" />
+        <Rule Id="CA1805" Action="None" />
+        <Rule Id="CA1810" Action="None" />
         <Rule Id="CA1812" Action="None" />
+        <Rule Id="CA1816" Action="None" />
         <Rule Id="CA1819" Action="None" />
+        <Rule Id="CA1822" Action="None" />
         <Rule Id="CA1823" Action="None" />
+        <Rule Id="CA1834" Action="None" />
+        <Rule Id="CA2016" Action="None" />
         <Rule Id="CA2211" Action="None" />
+        <Rule Id="CA2225" Action="None" />
+        <Rule Id="CA2227" Action="None" />
         <Rule Id="CA2252" Action="None" />
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
         <Rule Id="RCS1018" Action="None" />
         <Rule Id="RCS1079" Action="None" />
         <Rule Id="RCS1090" Action="None" />
+        <Rule Id="RCS1158" Action="None" />
         <Rule Id="RCS1163" Action="None" />
         <Rule Id="RCS1169" Action="None" />
+        <Rule Id="RCS1194" Action="None" />
         <Rule Id="RCS1202" Action="None" />
         <Rule Id="RCS1213" Action="None" />
         <Rule Id="RCS1225" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -23,8 +23,13 @@
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
         <Rule Id="IDE0003" Action="Error" />
         <Rule Id="IDE0005" Action="Error" />
+        <Rule Id="IDE0010" Action="None" />
         <Rule Id="IDE0040" Action="None" />
         <Rule Id="IDE0040WithoutSuggestion" Action="None" />        
+        <Rule Id="IDE0055" Action="None" />
+        <Rule Id="IDE0072" Action="None" />
+        <Rule Id="IDE0083" Action="None" />
+        <Rule Id="IDE0130" Action="None" />
         <Rule Id="IDE1006" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
@@ -42,13 +47,19 @@
         <Rule Id="CA1063" Action="None" />
         <Rule Id="CA1065" Action="None" />
         <Rule Id="CA1303" Action="None" />
+        <Rule Id="CA1309" Action="None" />
         <Rule Id="CA1710" Action="None" />
+        <Rule Id="CA1711" Action="None" />
         <Rule Id="CA1716" Action="None" />
         <Rule Id="CA1724" Action="None" />
+        <Rule Id="CA1725" Action="None" />
+        <Rule Id="CA1805" Action="None" />
         <Rule Id="CA1810" Action="None" />
         <Rule Id="CA1816" Action="None" />
         <Rule Id="CA1822" Action="None" />
         <Rule Id="CA1829" Action="Error" />
+        <Rule Id="CA1834" Action="None" />
+        <Rule Id="CA2016" Action="None" />
         <Rule Id="CA2211" Action="None" />
         <Rule Id="CA2225" Action="None" />
         <Rule Id="CA2227" Action="None" />


### PR DESCRIPTION
### Fixed

- Moving common rules found in **.editorconfig** files to rulesets to maintain it in one place instead.

