### PR TITLE
Changing to beta version of stylecop

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
         <NoWarn>CS1591;RCS1090;CA2252;CS8632;RCS1217</NoWarn>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>
 
     <!-- Package versions -->

--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
@@ -30,7 +30,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3"/>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"/>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354"/>
         <PackageReference Include="Roslynator.Analyzers" Version="3.2.2"/>
         <PackageReference Include="Meziantou.Analyzer" Version="1.0.670">
             <PrivateAssets>all</PrivateAssets>

--- a/Source/Defaults/Aksio.Defaults.csproj
+++ b/Source/Defaults/Aksio.Defaults.csproj
@@ -30,7 +30,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3"/>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"/>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354"/>
         <PackageReference Include="Roslynator.Analyzers" Version="3.2.2"/>
         <PackageReference Include="Meziantou.Analyzer" Version="1.0.670">
             <PrivateAssets>all</PrivateAssets>

--- a/Specifications/Directory.Build.props
+++ b/Specifications/Directory.Build.props
@@ -4,6 +4,7 @@
         <IsTestProject>true</IsTestProject>
         <NoWarn>CA1707;CA2252;CA2211;RCS1169;RCS1018;RCS1213;IDE0044;IDE0052;IDE1006;RCS1090;IDE0051;CA1051;CS8632;CS8618;RCS1225</NoWarn>
         <Nullable>disable</Nullable>
+        <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Fixed

- Official stable version `StyleCop.Analyzers` is 1.1.118 and it predates C#9 and records - the latest beta version 1.2.0-beta.354 supports this. Read more [here](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3213).

