### PR TITLE
Warnings-as-errors

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -21,6 +21,7 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
     <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <IsTestProject>false</IsTestProject>

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -21,6 +21,7 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>
     <StyleCopTreatErrorsAsWarnings>True</StyleCopTreatErrorsAsWarnings>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -68,6 +68,7 @@
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
         <Rule Id="RCS1018" Action="None" />
         <Rule Id="RCS1057" Action="Error" />
+        <Rule Id="RCS1079" Action="None" />
         <Rule Id="RCS1158" Action="None" />
         <Rule Id="RCS1182" Action="Error" />
         <Rule Id="RCS1194" Action="None" />


### PR DESCRIPTION
### Fixed

- Adding escalation of warnings to errors with new `MSBuildTreatWarningsAsErrors` to enable this for all code analysis rules. Read more [here](https://github.com/MicrosoftDocs/visualstudio-docs/issues/4660), discovered in [this workaround](https://github.com/dotnet/roslyn/issues/43051#issuecomment-631943470).
- Disabling RCS1079 for enabling the use of `NotImplementedException`.
