### PR TITLE
Disabling SA1516 - requiring whitespace in places we don't want :)

### DIFF
--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -18,6 +18,7 @@
         <Rule Id="SA1413" Action="None" />
         <Rule Id="SA1501" Action="None" />
         <Rule Id="SA1503" Action="None" />
+        <Rule Id="SA1516" Action="None" />
         <Rule Id="SA1633" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">


### PR DESCRIPTION
### Fixed

- Disabling SA1516 rule : Elements should be separated by blank line 
