### PR TITLE
Disabling SA1513

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -29,6 +29,7 @@
         <Rule Id="SA1413" Action="None" />
         <Rule Id="SA1501" Action="None" />
         <Rule Id="SA1502" Action="None" />
+        <Rule Id="SA1513" Action="None" />
         <Rule Id="SA1503" Action="None" />
         <Rule Id="SA1516" Action="None" />
         <Rule Id="SA1600" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -18,6 +18,7 @@
         <Rule Id="SA1413" Action="None" />
         <Rule Id="SA1501" Action="None" />
         <Rule Id="SA1503" Action="None" />
+        <Rule Id="SA1513" Action="None" />
         <Rule Id="SA1516" Action="None" />
         <Rule Id="SA1633" Action="None" />
     </Rules>


### PR DESCRIPTION
### Fixed

- Disabling rule SA1513: Closing brace should be followed by blank line.
