### PR TITLE
Disabling CA1404 - requirement of CLSCompliant

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -71,6 +71,7 @@
         <Rule Id="CA1307" Action="None" />
         <Rule Id="CA1308" Action="None" />
         <Rule Id="CA1309" Action="None" />
+        <Rule Id="CA1014" Action="None" />
         <Rule Id="CA1707" Action="None" />
         <Rule Id="CA1710" Action="None" />
         <Rule Id="CA1711" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -50,6 +50,7 @@
         <Rule Id="CA1065" Action="None" />
         <Rule Id="CA1303" Action="None" />
         <Rule Id="CA1309" Action="None" />
+        <Rule Id="CA1014" Action="None" />
         <Rule Id="CA1710" Action="None" />
         <Rule Id="CA1711" Action="None" />
         <Rule Id="CA1716" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling static code analysis rule CA1014 - requirement of `[CLSCompliant]` attribute on assemblies. This showed up as an error after upgrading to .NET Core 6 RC2. Might be something we can revert later.
