### PR TITLE
Disabling SA1128, SA1623, SA1642

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -14,6 +14,7 @@
         <Rule Id="SA1134" Action="None" />
         <Rule Id="SA1118" Action="None" />
         <Rule Id="SA1122" Action="None" />
+        <Rule Id="SA1128" Action="None" />
         <Rule Id="SA1201" Action="None" />
         <Rule Id="SA1302" Action="None" />
         <Rule Id="SA1300" Action="None" />
@@ -33,7 +34,9 @@
         <Rule Id="SA1503" Action="None" />
         <Rule Id="SA1516" Action="None" />
         <Rule Id="SA1600" Action="None" />
+        <Rule Id="SA1623" Action="None" />
         <Rule Id="SA1633" Action="None" />
+        <Rule Id="SA1642" Action="None" />
         <Rule Id="SA1649" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -8,6 +8,7 @@
         <Rule Id="SA1000" Action="None" />
         <Rule Id="SA1009" Action="None" />
         <Rule Id="SA1101" Action="None" />
+        <Rule Id="SA1128" Action="None" />
         <Rule Id="SA1200" Action="Error" />
         <Rule Id="SA1210" Action="Error" />
         <Rule Id="SA1300" Action="None" />
@@ -20,7 +21,9 @@
         <Rule Id="SA1503" Action="None" />
         <Rule Id="SA1513" Action="None" />
         <Rule Id="SA1516" Action="None" />
+        <Rule Id="SA1623" Action="None" />
         <Rule Id="SA1633" Action="None" />
+        <Rule Id="SA1642" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
         <Rule Id="IDE0003" Action="Error" />


### PR DESCRIPTION
### Fixed

- Disabling [SA1128](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1128.md) - Constructor initailizes must be on own line
- Disabling [SA1623](https://documentation.help/StyleCop/SA1623.html) - Property summary documentation must match accessor.
- Disabling [SA1642](https://documentation.help/StyleCop/SA1642.html) - Constructor summary documentation must begin with standard text.
