### PR TITLE
Disabling ConfigureAwait and Readability rules

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -16,7 +16,7 @@
 
     <LangVersion>10.0</LangVersion>
 
-    <NoWarn>$(NoWarn);NU5105;NU5118;CS1591;CS8632;CS8618</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5118;CS1591;CS8632;CS8618;CS0012</NoWarn> <!-- CS0012 - ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
     <Nullable>disable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -92,6 +92,7 @@
         <Rule Id="CA1822" Action="None" />
         <Rule Id="CA1823" Action="None" />
         <Rule Id="CA1834" Action="None" />
+        <Rule Id="CA2007" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="CA2016" Action="None" />
         <Rule Id="CA2211" Action="None" />
         <Rule Id="CA2225" Action="None" />
@@ -100,6 +101,7 @@
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
         <Rule Id="RCS1018" Action="None" />
+        <Rule Id="RCS1019" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="RCS1079" Action="None" />
         <Rule Id="RCS1090" Action="None" />
         <Rule Id="RCS1158" Action="None" />

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -12,6 +12,7 @@
         <Rule Id="SA1012" Action="None" />
         <Rule Id="SA1101" Action="None" />
         <Rule Id="SA1134" Action="None" />
+        <Rule Id="SA1115" Action="None" />
         <Rule Id="SA1118" Action="None" />
         <Rule Id="SA1122" Action="None" />
         <Rule Id="SA1128" Action="None" />

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -16,7 +16,7 @@
 
     <LangVersion>10.0</LangVersion>
 
-    <NoWarn>$(NoWarn);NU5105;NU5118</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5118;CS0012</NoWarn> <!-- CS0012 - ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>True</CodeAnalysisTreatWarningsAsErrors>

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -8,6 +8,7 @@
         <Rule Id="SA1000" Action="None" />
         <Rule Id="SA1009" Action="None" />
         <Rule Id="SA1101" Action="None" />
+        <Rule Id="SA1115" Action="None" />
         <Rule Id="SA1128" Action="None" />
         <Rule Id="SA1200" Action="Error" />
         <Rule Id="SA1210" Action="Error" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -67,6 +67,7 @@
         <Rule Id="CA1822" Action="None" />
         <Rule Id="CA1829" Action="Error" />
         <Rule Id="CA1834" Action="None" />
+        <Rule Id="CA2007" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="CA2016" Action="None" />
         <Rule Id="CA2211" Action="None" />
         <Rule Id="CA2225" Action="None" />
@@ -77,6 +78,7 @@
         <Rule Id="RCS1018" Action="None" />
         <Rule Id="RCS1057" Action="Error" />
         <Rule Id="RCS1079" Action="None" />
+        <Rule Id="RCS1019" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="RCS1158" Action="None" />
         <Rule Id="RCS1163" Action="None" />
         <Rule Id="RCS1182" Action="Error" />


### PR DESCRIPTION
### Fixed

- Disabling SA1115 - allowing empty lines between arguments. This to allow for comments related to arguments being passed in and not having to condensed of a view on it.
- Disabling warning related to having to add `ConfigureAwait()` to async calls (CS0012, RCS1090, CA2007). If running in an app model context, which eseentially we will do for all our stuff - this is just unwanted and not needed noise. Read more here: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse.

