### PR TITLE
Disable CA2234

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -97,6 +97,7 @@
         <Rule Id="CA2016" Action="None" />
         <Rule Id="CA2211" Action="None" />
         <Rule Id="CA2225" Action="None" />
+        <Rule Id="CA2234" Action="None" />
         <Rule Id="CA2227" Action="None" />
         <Rule Id="CA2252" Action="None" />
     </Rules>

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -74,6 +74,7 @@
         <Rule Id="CA2211" Action="None" />
         <Rule Id="CA2225" Action="None" />
         <Rule Id="CA2227" Action="None" />
+        <Rule Id="CA2234" Action="None" />
         <Rule Id="CA2252" Action="None" />
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">


### PR DESCRIPTION
### Fixed

- Disable CA2234 - disallowing specific API call. Weird rule - why not mark this as obsolete if its not a desirable API call.
