### PR TITLE
Disabling CA2000 for specs

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -93,6 +93,7 @@
         <Rule Id="CA1822" Action="None" />
         <Rule Id="CA1823" Action="None" />
         <Rule Id="CA1834" Action="None" />
+        <Rule Id="CA2000" Action="None" />
         <Rule Id="CA2007" Action="None" /> <!-- ConfigureAwait: https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse -->
         <Rule Id="CA2016" Action="None" />
         <Rule Id="CA2211" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling CA2000 for specs. Not requiring using statements in specs.