### PR TITLE
Disabling CA5394

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -101,6 +101,7 @@
         <Rule Id="CA2234" Action="None" />
         <Rule Id="CA2227" Action="None" />
         <Rule Id="CA2252" Action="None" />
+        <Rule Id="CA5394" Action="None" />
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
         <Rule Id="RCS1018" Action="None" />

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -76,6 +76,7 @@
         <Rule Id="CA2227" Action="None" />
         <Rule Id="CA2234" Action="None" />
         <Rule Id="CA2252" Action="None" />
+        <Rule Id="CA5394" Action="None" />
     </Rules>
     <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
         <Rule Id="RCS1018" Action="None" />


### PR DESCRIPTION
### Fixed

- Disabling CA5394 - Random is random enough for our purposes and for cryptography we would use a cryptography API.
