### PR TITLE
Disabling CA5394

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ These props files configures a default behavior for builds with a [common set of
 [stylecop rules](./Source/Defaults/stylecop.json). In addition to this it provides a set of default NuGet metadata properties to ease
 the creation of projects that are to be published as NuGet packages.
 
+With the introduction of [Global AnalyserConfig](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig) one can
+take typical things one would hav ein `.editorconfig` files and package for reuse. This project does so as well by adding
+
 ### Packages
 
 NuGet packages that are published on the public NuGet feed should adhere to the defined [best practices](https://docs.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices).

--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
@@ -44,6 +44,7 @@
         <Content Include="code_analysis.ruleset" PackagePath="build\" />
         <Content Include="../Defaults/code_analysis.ruleset" PackagePath="build\code_analysis_base.ruleset" />
         <Content Include="../Defaults/stylecop.json" PackagePath="build\" />
+        <Content Include="../Defaults/.editorconfig" PackagePath="build\" />
         <Content Remove="bin\**" CopyToPublishDirectory="Never" />
     </ItemGroup>
 

--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -34,6 +34,8 @@
     <RunAnalyzers>True</RunAnalyzers>
 
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+
+    <GlobalAnalyzerConfigFiles>$(MSBuildThisFileDirectory).editorconfig</GlobalAnalyzerConfigFiles>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/Source/Defaults/.editorconfig
+++ b/Source/Defaults/.editorconfig
@@ -1,0 +1,105 @@
+is_global = true
+end_of_line = lf
+indent_style = space
+indent_size = 4
+charset = utf-8
+dotnet_analyzer_diagnostic.severity = warning
+
+#### .NET Conventions ####
+dotnet_sort_system_directives_first = true:error
+
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# dont prefer ifs over ternary operators
+dotnet_style_prefer_conditional_expression_over_return = true:none
+dotnet_style_prefer_conditional_expression_over_assignment = true:none
+# dont need to declare private
+dotnet_style_require_accessibility_modifiers = never:error
+
+# consts are pascal case
+dotnet_naming_rule.const_fields.symbols                                         = const_fields
+dotnet_naming_rule.const_fields.style                                           = const_fields
+dotnet_naming_rule.const_fields.severity                                        = suggestion
+
+dotnet_naming_symbols.const_fields.applicable_kinds                             = field
+dotnet_naming_symbols.const_fields.applicable_accessibilities                   = *
+dotnet_naming_symbols.const_fields.required_modifiers                           = const
+
+dotnet_naming_style.const_fields.capitalization                                 = pascal_case
+dotnet_naming_style.const_fields.required_prefix                                = 
+
+# public static fields are pascal case
+dotnet_naming_rule.static_readonly_fields.symbols                               = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields.style                                 = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields.severity                              = suggestion
+
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds                   = field
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities         = public
+dotnet_naming_symbols.static_readonly_fields.required_modifiers                 = static
+
+dotnet_naming_style.static_readonly_fields.capitalization                       = pascal_case
+dotnet_naming_style.static_readonly_fields.required_prefix                      = 
+
+# private fields should be camel case and start with _
+dotnet_naming_rule.private_Fields.symbols                                       = private_fields
+dotnet_naming_rule.private_Fields.style                                         = private_fields
+dotnet_naming_rule.private_Fields.severity                                      = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds                           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities                 = private
+dotnet_naming_symbols.private_fields.required_modifiers                         = 
+
+dotnet_naming_style.private_fields.capitalization                               = camel_case
+dotnet_naming_style.private_fields.required_prefix                              = _
+
+
+
+# upper camelcase for public properties
+dotnet_naming_rule.public_members_must_be_capitalized.style = first_word_upper_case_style
+dotnet_naming_style.first_word_upper_case_style.capitalization = first_word_upper
+dotnet_naming_rule.public_members_must_be_capitalized.symbols = public_symbols
+dotnet_naming_symbols.public_symbols.applicable_kinds = property,method,field,event,delegate
+dotnet_naming_symbols.public_symbols.applicable_accessibilities = public
+dotnet_naming_symbols.public_symbols.required_modifiers = readonly
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true:error
+csharp_style_var_for_built_in_types = true:error
+csharp_style_var_when_type_is_apparent = true:error
+
+# use 'new' when possible
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+
+# curly bois preferred on multiline
+csharp_prefer_braces = when_multiline:error
+# we're ok with both old and new types of switches
+csharp_style_prefer_switch_expression = true:none
+
+# allow both => and regular blocks {}
+csharp_style_expression_bodied_methods = true:none
+csharp_style_expression_bodied_operators = true:none
+csharp_style_expression_bodied_constructors = true:none
+csharp_style_expression_bodied_local_functions = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# allow both local and anonymous functions
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# dont need to save everything to a var
+csharp_style_unused_value_expression_statement_preference = false:none
+
+# not ready for changing everything to pattern matching
+csharp_style_prefer_pattern_matching = false:none
+csharp_using_directive_placement = outside_namespace:error
+csharp_style_prefer_range_operator = false:none
+
+# CSharp formatting rules:
+# dont want these bombing the build logs, will still show up in the IDE
+# prefere brace indentation when creating objects etc
+csharp_indent_braces = false

--- a/Source/Defaults/Aksio.Defaults.csproj
+++ b/Source/Defaults/Aksio.Defaults.csproj
@@ -44,6 +44,7 @@
         <Content Include="../../logo.png" PackagePath="build\" />
         <Content Include="code_analysis.ruleset" PackagePath="build\" />
         <Content Include="stylecop.json" PackagePath="build\" />
+        <Content Include=".editorconfig" PackagePath="build\" />
         <Content Remove="bin\**" CopyToPublishDirectory="Never" />
     </ItemGroup>
 

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -36,6 +36,8 @@
     <RunAnalyzers>True</RunAnalyzers>
 
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+
+    <GlobalAnalyzerConfigFiles>$(MSBuildThisFileDirectory).editorconfig</GlobalAnalyzerConfigFiles>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
### Added

- Adding a global `.editorconfig` file to get all of our naming styles standardized for projects. Leveraging the [GlobalAnalyzerConfig](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig) option