### PR TITLE
Enforce-style-in-build

### DIFF
--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.csproj
@@ -29,6 +29,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.0.1">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3"/>
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354"/>
         <PackageReference Include="Roslynator.Analyzers" Version="3.2.2"/>

--- a/Source/Defaults.Specs/Aksio.Defaults.Specs.props
+++ b/Source/Defaults.Specs/Aksio.Defaults.Specs.props
@@ -35,6 +35,7 @@
 
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GlobalAnalyzerConfigFiles>$(MSBuildThisFileDirectory).editorconfig</GlobalAnalyzerConfigFiles>
   </PropertyGroup>
 

--- a/Source/Defaults/.editorconfig
+++ b/Source/Defaults/.editorconfig
@@ -45,9 +45,9 @@ dotnet_naming_style.static_readonly_fields.capitalization                       
 dotnet_naming_style.static_readonly_fields.required_prefix                      = 
 
 # private fields should be camel case and start with _
-dotnet_naming_rule.private_Fields.symbols                                       = private_fields
-dotnet_naming_rule.private_Fields.style                                         = private_fields
-dotnet_naming_rule.private_Fields.severity                                      = error
+dotnet_naming_rule.private_fields.symbols                                       = private_fields
+dotnet_naming_rule.private_fields.style                                         = private_fields
+dotnet_naming_rule.private_fields.severity                                      = error
 
 dotnet_naming_symbols.private_fields.applicable_kinds                           = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities                 = private

--- a/Source/Defaults/.editorconfig
+++ b/Source/Defaults/.editorconfig
@@ -23,7 +23,7 @@ dotnet_style_require_accessibility_modifiers = never:error
 # consts are pascal case
 dotnet_naming_rule.const_fields.symbols                                         = const_fields
 dotnet_naming_rule.const_fields.style                                           = const_fields
-dotnet_naming_rule.const_fields.severity                                        = suggestion
+dotnet_naming_rule.const_fields.severity                                        = error
 
 dotnet_naming_symbols.const_fields.applicable_kinds                             = field
 dotnet_naming_symbols.const_fields.applicable_accessibilities                   = *
@@ -35,7 +35,7 @@ dotnet_naming_style.const_fields.required_prefix                                
 # public static fields are pascal case
 dotnet_naming_rule.static_readonly_fields.symbols                               = static_readonly_fields
 dotnet_naming_rule.static_readonly_fields.style                                 = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields.severity                              = suggestion
+dotnet_naming_rule.static_readonly_fields.severity                              = error
 
 dotnet_naming_symbols.static_readonly_fields.applicable_kinds                   = field
 dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities         = public
@@ -47,7 +47,7 @@ dotnet_naming_style.static_readonly_fields.required_prefix                      
 # private fields should be camel case and start with _
 dotnet_naming_rule.private_Fields.symbols                                       = private_fields
 dotnet_naming_rule.private_Fields.style                                         = private_fields
-dotnet_naming_rule.private_Fields.severity                                      = suggestion
+dotnet_naming_rule.private_Fields.severity                                      = error
 
 dotnet_naming_symbols.private_fields.applicable_kinds                           = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities                 = private

--- a/Source/Defaults/Aksio.Defaults.csproj
+++ b/Source/Defaults/Aksio.Defaults.csproj
@@ -29,9 +29,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3"/>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354"/>
-        <PackageReference Include="Roslynator.Analyzers" Version="3.2.2"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.0.1">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" />
+        <PackageReference Include="Roslynator.Analyzers" Version="3.2.2" />
         <PackageReference Include="Meziantou.Analyzer" Version="1.0.670">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -50,7 +54,7 @@
 
 
     <Target Name="PublishCodeAnalysis" BeforeTargets="GenerateNuspec">
-        <Exec Command="dotnet publish -c $(Configuration)" WorkingDirectory="..\CodeAnalysis"/>
+        <Exec Command="dotnet publish -c $(Configuration)" WorkingDirectory="..\CodeAnalysis" />
     </Target>
 
     <Target Name="PackTaskDependencies" AfterTargets="PublishCodeAnalysis">

--- a/Source/Defaults/Aksio.Defaults.props
+++ b/Source/Defaults/Aksio.Defaults.props
@@ -37,6 +37,7 @@
 
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GlobalAnalyzerConfigFiles>$(MSBuildThisFileDirectory).editorconfig</GlobalAnalyzerConfigFiles>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Trying to 

### Added

- Added `<EnforceCodeStyleInBuild/>` for props files.
- Added explicit package reference to `Microsoft.CodeAnalysis.CSharp.CodeStyle`.

### Fixed

- Setting severity to error for C# naming rules.
