### PR TITLE
Fixing-editorconfig-usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ These props files configures a default behavior for builds with a [common set of
 the creation of projects that are to be published as NuGet packages.
 
 With the introduction of [Global AnalyserConfig](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig) one can
-take typical things one would hav ein `.editorconfig` files and package for reuse. This project does so as well by adding
+take typical things one would hav ein `.editorconfig` files and package for reuse. This project does so as well by adding a global editorconfig.
+For examples on how these can be set up look [here](https://github.com/dotnet/roslyn/blob/main/.editorconfig) or [here](https://gist.github.com/bryanknox/e07027d4d32e0288e488b918545786c8).
 
 ### Packages
 

--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -51,7 +51,6 @@
         <Rule Id="IDE0072" Action="None" />
         <Rule Id="IDE0083" Action="None" />
         <Rule Id="IDE0130" Action="None" />
-        <Rule Id="IDE1006" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
     </Rules>  

--- a/Source/Defaults/.editorconfig
+++ b/Source/Defaults/.editorconfig
@@ -8,11 +8,11 @@ dotnet_analyzer_diagnostic.severity = error
 #### .NET Conventions ####
 dotnet_sort_system_directives_first = true:error
 
-# Avoid "this." and "Me." if not necessary
-dotnet_style_qualification_for_field = false:error
-dotnet_style_qualification_for_property = false:error
-dotnet_style_qualification_for_method = false:error
-dotnet_style_qualification_for_event = false:error
+# Avoid "this." if not necessary
+dotnet_style_qualification_for_field                                            = false:error
+dotnet_style_qualification_for_property                                         = false:error
+dotnet_style_qualification_for_method                                           = false:error
+dotnet_style_qualification_for_event                                            = false:error
 
 # dont prefer ifs over ternary operators
 dotnet_style_prefer_conditional_expression_over_return = true:none
@@ -69,37 +69,37 @@ dotnet_naming_style.public_symbols.capitalization                               
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = true:error
-csharp_style_var_for_built_in_types = true:error
-csharp_style_var_when_type_is_apparent = true:error
+csharp_style_var_elsewhere                                                      = true:error
+csharp_style_var_for_built_in_types                                             = true:error
+csharp_style_var_when_type_is_apparent                                          = true:error
 
 # use 'new' when possible
-csharp_style_implicit_object_creation_when_type_is_apparent = true:error
+csharp_style_implicit_object_creation_when_type_is_apparent                     = true:error
 
 # curly bois preferred on multiline
-csharp_prefer_braces = when_multiline:error
+csharp_prefer_braces                                                            = when_multiline:error
 # we're ok with both old and new types of switches
-csharp_style_prefer_switch_expression = true:none
+csharp_style_prefer_switch_expression                                           = true:none
 
 # allow both => and regular blocks {}
-csharp_style_expression_bodied_methods = true:none
-csharp_style_expression_bodied_operators = true:none
-csharp_style_expression_bodied_constructors = true:none
-csharp_style_expression_bodied_local_functions = true:none
-csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_methods                                          = true:none
+csharp_style_expression_bodied_operators                                        = true:none
+csharp_style_expression_bodied_constructors                                     = true:none
+csharp_style_expression_bodied_local_functions                                  = true:none
+csharp_style_expression_bodied_accessors                                        = true:none
 
 # allow both local and anonymous functions
-csharp_style_pattern_local_over_anonymous_function = false:none
+csharp_style_pattern_local_over_anonymous_function                              = false:none
 
 # dont need to save everything to a var
-csharp_style_unused_value_expression_statement_preference = false:none
+csharp_style_unused_value_expression_statement_preference                       = false:none
 
 # not ready for changing everything to pattern matching
-csharp_style_prefer_pattern_matching = false:none
-csharp_using_directive_placement = outside_namespace:error
-csharp_style_prefer_range_operator = false:none
+csharp_style_prefer_pattern_matching                                            = false:none
+csharp_using_directive_placement                                                = outside_namespace:error
+csharp_style_prefer_range_operator                                              = false:none
 
 # CSharp formatting rules:
 # dont want these bombing the build logs, will still show up in the IDE
 # prefere brace indentation when creating objects etc
-csharp_indent_braces = false
+csharp_indent_braces                                                            = false

--- a/Source/Defaults/code_analysis.ruleset
+++ b/Source/Defaults/code_analysis.ruleset
@@ -37,7 +37,6 @@
         <Rule Id="IDE0072" Action="None" />
         <Rule Id="IDE0083" Action="None" />
         <Rule Id="IDE0130" Action="None" />
-        <Rule Id="IDE1006" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
     </Rules>  


### PR DESCRIPTION
\#\#\# Fixed

\- Disabling [IDE1006](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules#rule-id-ide1006-naming-rule-violation), which effectively nulled out anything trying to use the `.editorconfig` for diagnostics & style rules.
