### PR TITLE
Disable naming rules IDE1006 for specs

### DIFF
--- a/Source/Defaults.Specs/code_analysis.ruleset
+++ b/Source/Defaults.Specs/code_analysis.ruleset
@@ -51,6 +51,7 @@
         <Rule Id="IDE0072" Action="None" />
         <Rule Id="IDE0083" Action="None" />
         <Rule Id="IDE0130" Action="None" />
+        <Rule Id="IDE1006" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.EditorFeatures" RuleNamespace="Microsoft.CodeAnalysis.CSharp.EditorFeatures">
     </Rules>  


### PR DESCRIPTION
### Fixed

- Disable naming rules IDE1006 for specs.